### PR TITLE
Lookup topic controller in the container

### DIFF
--- a/assets/javascripts/discourse/initializers/iso-init.js.es6
+++ b/assets/javascripts/discourse/initializers/iso-init.js.es6
@@ -1,15 +1,8 @@
 import { withPluginApi } from 'discourse/lib/plugin-api'
 import TopicRoute from 'discourse/routes/topic'
 
-function initializePlugin(api) {
-let topicController;
-
-  TopicRoute.reopen({
-    setupController(controller, model) {
-      this._super(controller, model);
-      topicController = controller;
-    }
-  });
+function initializePlugin(api, container) {
+  const topicController = container.lookup('controller:topic');
 
   api.addPostMenuButton('iso', attrs => {
 
@@ -39,7 +32,7 @@ let topicController;
 
 export default {
   name: 'iso-button',
-  initialize: function() {
-    withPluginApi('0.8.6', api => initializePlugin(api))
+  initialize: function(container) {
+    withPluginApi('0.8.6', api => initializePlugin(api, container))
   }
 }


### PR DESCRIPTION
@kcereru Hey! Nice to e-meet you :)

Would love to have a chat sometime about Discourse development if you're keen. Looks like you've been getting into it with Eli.

The best way to get the topic controller in an initializer is to look it up in registry (or "container"). Dependency injection is explained in some detail here: https://guides.emberjs.com/release/applications/dependency-injection/.

Note:

> By default, registrations are treated as "singletons". This simply means that an instance will be created when it is first looked up, and this same instance will be cached and returned from subsequent lookups.

There's only one topic controller, so you can just store that in a constant and use it however you like in your initializer.

In general I would recommend the Ember Guides to get a general overview of the Discourse client structure, in particular how routes, controllers templates and models all interact with each other.

